### PR TITLE
Fix: sync input clearing to all provider panels

### DIFF
--- a/src/preload/chatgpt-preload.js
+++ b/src/preload/chatgpt-preload.js
@@ -68,7 +68,7 @@ const submitMessage = createSubmitHandler(
   null
 );
 
-setupIPCListeners(provider, config, injectText, submitMessage, { value: lastText });
+setupIPCListeners(provider, config, injectText, submitMessage);
 
 setupInputScanner(
   provider,

--- a/src/preload/claude-preload.js
+++ b/src/preload/claude-preload.js
@@ -74,7 +74,7 @@ const submitMessage = createSubmitHandler(
   null
 );
 
-setupIPCListeners(provider, config, injectText, submitMessage, { value: lastText });
+setupIPCListeners(provider, config, injectText, submitMessage);
 
 setupInputScanner(
   provider,

--- a/src/preload/gemini-preload.js
+++ b/src/preload/gemini-preload.js
@@ -88,7 +88,7 @@ const submitMessage = createSubmitHandler(
   null
 );
 
-setupIPCListeners(provider, config, injectText, submitMessage, { value: lastText });
+setupIPCListeners(provider, config, injectText, submitMessage);
 
 setupInputScanner(
   provider,

--- a/src/preload/grok-preload.js
+++ b/src/preload/grok-preload.js
@@ -70,7 +70,7 @@ const submitMessage = createSubmitHandler(
   null
 );
 
-setupIPCListeners(provider, config, injectText, submitMessage, { value: lastText });
+setupIPCListeners(provider, config, injectText, submitMessage);
 
 setupInputScanner(
   provider,

--- a/src/preload/perplexity-preload.js
+++ b/src/preload/perplexity-preload.js
@@ -119,7 +119,7 @@ const submitMessage = createSubmitHandler(
   null
 );
 
-setupIPCListeners(provider, config, injectText, submitMessage, { value: lastText });
+setupIPCListeners(provider, config, injectText, submitMessage);
 
 setupInputScanner(
   provider,

--- a/src/preload/shared-preload-utils.js
+++ b/src/preload/shared-preload-utils.js
@@ -67,9 +67,11 @@ function createSubmitHandler(provider, config, getInputElement, getSubmitElement
   };
 }
 
-function setupIPCListeners(provider, config, injectTextFn, submitFn, lastText) {
+function setupIPCListeners(provider, config, injectTextFn, submitFn) {
+  let lastSentText = null;
   ipcRenderer.on('text-update', (event, text) => {
-    if (text !== lastText.value) {
+    if (text !== lastSentText) {
+      lastSentText = text;
       injectTextFn(text);
     }
   });


### PR DESCRIPTION
When you typed something in the main input and then deleted it, the text would
  remain stuck in the ChatGPT, Gemini, and other provider panels.

  Root cause: the deduplication check in setupIPCListeners used a broken object
  reference that always held '', so clearing the input (sending an empty string) was
  silently ignored and never forwarded to the provider panels.

  Fix: track lastSentText inside setupIPCListeners via a proper closure variable so
  empty strings are correctly propagated.

  ## Test plan
  - Typed text — mirrored correctly to all providers
  - Deleted all text — all provider panels cleared correctly
  - Tested on ChatGPT, Gemini, Perplexity, Claude

  ## Screenshots
  Before:

<img width="1428" height="623" alt="Screenshot 2026-03-08 at 16 40 40" src="https://github.com/user-attachments/assets/5f6209b7-aa5f-4501-8f99-218764482b13" />

  After Fix:

https://github.com/user-attachments/assets/5b5ddac9-871e-4923-acb3-1c9fa9a16337



