### PR TITLE
Add Kimi (kimi.com) as a sixth provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # PolyGPT
 
 Interact with multiple AI assistants simultaneously in a split-screen interface. 
-Type once and send your prompts to ChatGPT, Claude, Gemini, and Perplexity at the same time.
+Type once and send your prompts to ChatGPT, Claude, Gemini, Perplexity, Grok, and Kimi at the same time.
 
 ## Demo
 
@@ -18,7 +18,8 @@ Type once and send your prompts to ChatGPT, Claude, Gemini, and Perplexity at th
 
 ## Features
 
-- **4-way split view** - ChatGPT, Claude, Gemini, and Perplexity in a 2x2 grid
+- **4-way split view** - any four providers at once in a 2x2 grid
+- **Six providers** - ChatGPT, Claude, Gemini, Perplexity, Grok, and Kimi
 - **Unified input** - Type once, send to all providers simultaneously
 - **Provider switching** - Change any quadrant to a different provider on the fly
 - **Supersize mode** - Expand any quadrant to 80% width for focused work

--- a/config/selectors.json
+++ b/config/selectors.json
@@ -74,6 +74,21 @@
       "button[title*='New chat']"
     ]
   },
+  "kimi": {
+    "input": [
+      "div.chat-input-editor[data-lexical-editor='true']",
+      "div.chat-input-editor",
+      "[data-lexical-editor='true'][role='textbox']"
+    ],
+    "submit": [
+      ".send-button-container",
+      "button[aria-label*='Send']"
+    ],
+    "newChat": [
+      "a.new-chat-btn",
+      "a[href*='chat_enter_method=new_chat']"
+    ]
+  },
   "grok": {
     "input": [
       "[data-testid='Grok_Compose_Textarea_ID']",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polygpt",
   "version": "0.2.8",
-  "description": "Mirror text to ChatGPT and Gemini simultaneously",
+  "description": "Mirror text to multiple AI chat providers simultaneously",
   "author": {
     "name": "Nathan Cavaglione",
     "email": "nathan@polygpt.app"

--- a/src/main/window-manager.js
+++ b/src/main/window-manager.js
@@ -34,6 +34,14 @@ const PROVIDERS = {
     name: 'Grok',
     userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
   },
+  kimi: {
+    url: 'https://www.kimi.com',
+    preload: 'kimi-preload.js',
+    name: 'Kimi',
+    // Verified: kimi.com serves the full app to Electron's default UA (HTTP 200,
+    // composer present), so no override is needed.
+    userAgent: null,
+  },
 };
 
 // Position keys
@@ -42,23 +50,40 @@ const POSITIONS = ['topLeft', 'topRight', 'bottomLeft', 'bottomRight'];
 // Config file path
 const CONFIG_PATH = path.join(__dirname, '../../config/window-providers.json');
 
-// Load provider configuration
+// Default layout, also the fallback for any slot that fails validation
+const DEFAULT_PROVIDER_CONFIG = {
+  topLeft: "claude",
+  topRight: "grok",
+  bottomLeft: "chatgpt",
+  bottomRight: "gemini"
+};
+
+// Load provider configuration. The file lives in userland and is gitignored, so a
+// stale or hand-edited key must not be fatal: createProviderView throws on an
+// unknown provider, and that throw would escape createWindow() and leave the app
+// with no visible window at all. Fall back per slot instead.
 function loadProviderConfig() {
+  let stored = null;
   try {
     if (fs.existsSync(CONFIG_PATH)) {
-      const data = fs.readFileSync(CONFIG_PATH, 'utf8');
-      return JSON.parse(data);
+      stored = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
     }
   } catch (error) {
     console.error('Failed to load provider config:', error);
   }
-  // Return default configuration
-  return {
-    topLeft: "claude",
-    topRight: "grok",
-    bottomLeft: "chatgpt",
-    bottomRight: "gemini"
-  };
+
+  const config = { ...DEFAULT_PROVIDER_CONFIG };
+  if (stored && typeof stored === 'object') {
+    POSITIONS.forEach(pos => {
+      const key = stored[pos];
+      if (PROVIDERS[key]) {
+        config[pos] = key;
+      } else if (key !== undefined) {
+        console.error(`Ignoring unknown provider "${key}" at ${pos}; using "${config[pos]}"`);
+      }
+    });
+  }
+  return config;
 }
 
 // Save provider configuration
@@ -316,17 +341,19 @@ async function createWindow() {
 
   // Change provider for a position
   function changeProvider(position, newProviderKey, zoomFactor = 1.0) {
-    // Get old view
-    const oldView = viewPositions[position];
-
-    // Remove from window
-    mainWindow.contentView.removeChildView(oldView);
-
-    // Close old view
-    oldView.webContents.close();
-
-    // Create new view
+    // Build the replacement first. createProviderView throws on an unknown
+    // provider key, and tearing the old view down beforehand would leave a
+    // destroyed webContents in viewPositions that every later broadcast trips on.
+    if (!PROVIDERS[newProviderKey]) {
+      console.error(`Refusing to switch ${position} to unknown provider "${newProviderKey}"`);
+      return false;
+    }
     const newView = createProviderView(newProviderKey, position);
+
+    // Retire the old view only once the new one exists
+    const oldView = viewPositions[position];
+    mainWindow.contentView.removeChildView(oldView);
+    oldView.webContents.close();
 
     // Add to window
     mainWindow.contentView.addChildView(newView);

--- a/src/preload/kimi-preload.js
+++ b/src/preload/kimi-preload.js
@@ -1,0 +1,175 @@
+const { ipcRenderer } = require('electron');
+const {
+  loadConfig,
+  findElement,
+  createSubmitHandler,
+  setupIPCListeners,
+  setupInputScanner,
+  createUIControls,
+  setupViewInfoListener,
+  setupSupersizeListener,
+  setupLoadingOverlay,
+  waitForDOM,
+} = require('./shared-preload-utils');
+
+const config = loadConfig();
+const provider = 'kimi';
+
+// Kimi's composer is a Lexical editor (div.chat-input-editor[data-lexical-editor]).
+// Lexical keeps its own selection model and reconciles asynchronously, which rules
+// out every technique the other providers use. What was measured against the live
+// site:
+//   - programmatic DOM Ranges never reach Lexical, so selection-based edits no-op
+//   - a burst of synchronous edits in one tick all act on the same stale state,
+//     so N sequential deletes remove exactly one character
+//   - insertText silently truncates at the first newline
+//   - execCommand('insertLineBreak') wipes the whole editor
+// What does work is a single atomic operation per call: execCommand('selectAll'),
+// yield a tick so Lexical syncs its selection from the DOM, then either paste the
+// full text (replaces the selection, newlines intact) or send Backspace to clear.
+// Because that needs to await, injectText is async and coalesces latest-wins.
+const SELECTION_SYNC_MS = 20;
+
+let inputElement = null;
+
+function findKimiInput(element) {
+  if (!element) return null;
+  if (element.isContentEditable || element.tagName === 'TEXTAREA') return element;
+  const inner = element.querySelector('[contenteditable="true"], textarea');
+  return inner || element;
+}
+
+// Read the editor back the way the control bar spells it: <br> and block
+// boundaries become newlines. Trailing newlines are dropped because Lexical's
+// empty state is <p><br></p>, which would otherwise read as "\n".
+function readEditor(element) {
+  if (!element) return '';
+  if (element.tagName === 'TEXTAREA' || element.tagName === 'INPUT') return element.value;
+  const BLOCK = new Set(['P', 'DIV', 'LI', 'BLOCKQUOTE', 'PRE']);
+  let out = '';
+  (function walk(node) {
+    for (const child of node.childNodes) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        out += child.nodeValue;
+      } else if (child.nodeType === Node.ELEMENT_NODE) {
+        if (child.tagName === 'BR') {
+          out += '\n';
+          continue;
+        }
+        const isBlock = BLOCK.has(child.tagName) || getComputedStyle(child).display.startsWith('block');
+        if (isBlock && out && !out.endsWith('\n')) out += '\n';
+        walk(child);
+      }
+    }
+  })(element);
+  return normalize(out);
+}
+
+function normalize(text) {
+  return String(text == null ? '' : text)
+    .replace(/[\u200b\ufeff]/g, '')  // Lexical placeholder zero-width chars
+    .replace(/\u00a0/g, ' ')         // contenteditable turns space runs into nbsp
+    .replace(/\r\n?/g, '\n')
+    .replace(/\n+$/, '');
+}
+
+function pasteInto(element, text) {
+  const data = new DataTransfer();
+  data.setData('text/plain', text);
+  element.dispatchEvent(new ClipboardEvent('paste', {
+    clipboardData: data,
+    bubbles: true,
+    cancelable: true,
+  }));
+}
+
+function pressBackspace(element) {
+  const options = {
+    key: 'Backspace',
+    code: 'Backspace',
+    keyCode: 8,
+    which: 8,
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  };
+  element.dispatchEvent(new KeyboardEvent('keydown', options));
+  element.dispatchEvent(new KeyboardEvent('keyup', options));
+}
+
+async function writeText(text) {
+  inputElement = findKimiInput(findElement(config.kimi?.input));
+
+  if (!inputElement) {
+    ipcRenderer.invoke('selector-error', 'kimi', 'Input element not found');
+    return;
+  }
+
+  const wanted = normalize(text);
+  if (readEditor(inputElement) === wanted) return;
+
+  inputElement.focus();
+  document.execCommand('selectAll');
+  await new Promise((resolve) => setTimeout(resolve, SELECTION_SYNC_MS));
+
+  if (wanted.length === 0) {
+    pressBackspace(inputElement);
+  } else {
+    pasteInto(inputElement, wanted);
+  }
+}
+
+// Keystrokes arrive faster than a write completes, so keep only the newest and
+// replay it once the in-flight write settles.
+let pendingText = null;
+let hasPending = false;
+let writing = false;
+
+function injectText(text) {
+  pendingText = text;
+  hasPending = true;
+  if (writing) return;
+  writing = true;
+  (async () => {
+    try {
+      while (hasPending) {
+        const next = pendingText;
+        hasPending = false;
+        await writeText(next);
+      }
+    } finally {
+      writing = false;
+    }
+  })();
+}
+
+const submitMessage = createSubmitHandler(
+  provider,
+  config,
+  () => inputElement,
+  null
+);
+
+setupIPCListeners(provider, config, injectText, submitMessage);
+
+setupInputScanner(
+  provider,
+  config,
+  () => inputElement,
+  (el) => { inputElement = el; },
+  (selectors) => findKimiInput(findElement(selectors))
+);
+
+const getViewInfo = setupViewInfoListener((viewInfo) => {
+  window.polygptGetViewInfo = () => viewInfo;
+  createUIControls(viewInfo);
+});
+
+setupSupersizeListener();
+
+setupLoadingOverlay();
+
+waitForDOM(() => {
+  const viewInfo = getViewInfo();
+  if (viewInfo) createUIControls(viewInfo);
+});

--- a/src/preload/shared-preload-utils.js
+++ b/src/preload/shared-preload-utils.js
@@ -196,7 +196,12 @@ function styleDropdown(dropdown) {
     background: 'rgba(0, 0, 0, 0.9)',
     backdropFilter: 'blur(4px)',
     zIndex: '10000000',
-    overflow: 'hidden',
+    // Cap the height and scroll instead of growing: a supersized thumbnail panel
+    // is only ~chatAreaHeight/3 tall, so a full provider list would otherwise
+    // run past the bottom edge with no way to reach the last option.
+    maxHeight: '220px',
+    overflowY: 'auto',
+    overflowX: 'hidden',
     boxSizing: 'border-box',
     margin: '0',
     padding: '0',

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -12,15 +12,15 @@
       <textarea
         id="textInput"
         class="text-input"
-        placeholder="Type here to mirror to ChatGPT, Gemini, Perplexity, and Claude..."
+        placeholder="Type here to mirror to every panel..."
         spellcheck="true"
       ></textarea>
       <div class="input-info">
         <span><span id="charCount">0</span> characters</span>
         <span><kbd>Enter</kbd> to submit | <kbd>Shift+Enter</kbd> for new line</span>
         <div class="button-group">
-          <button id="newChatBtn" class="action-btn new-chat-btn" title="Start new chat in both">✨ New Chat</button>
-          <button id="refreshBtn" class="action-btn refresh-btn" title="Refresh both pages">🔄 Refresh</button>
+          <button id="newChatBtn" class="action-btn new-chat-btn" title="Start a new chat in every panel">✨ New Chat</button>
+          <button id="refreshBtn" class="action-btn refresh-btn" title="Refresh every panel">🔄 Refresh</button>
           <button id="zoomOutBtn" class="action-btn zoom-btn zoom-out-btn" title="Zoom out">−</button>
           <button id="zoomInBtn" class="action-btn zoom-btn zoom-in-btn" title="Zoom in">+</button>
         </div>


### PR DESCRIPTION
## Summary

Adds **Kimi** (`kimi.com`, Moonshot AI) as a sixth provider, selectable from any quadrant's dropdown. The default 2x2 layout is unchanged (Claude/Grok/ChatGPT/Gemini) — Kimi is opt-in per quadrant and persists once chosen.

Also fixes two pre-existing bugs that adding a sixth provider exposes. See *Out of scope* if you'd prefer those split out.

## Why `injectText` looks different from the others

Kimi's composer is a **Lexical editor — the same engine Perplexity uses** — so the obvious move is to copy `perplexity-preload.js`. That does not work: text accumulates and characters land at the front. Measured against the live site:

| Technique | Result on Kimi |
|---|---|
| Programmatic DOM `Range` / `selectAll` | Sets the DOM selection, but **never reaches Lexical's own selection model** → selection-based edits are silent no-ops |
| A burst of synchronous edits in one tick | Lexical reconciles **asynchronously**, so they all act on the same stale state — 11 backspaces removed **1** character |
| `execCommand('insertText', text)` | Silently **truncates at the first `\n`** |
| `execCommand('insertLineBreak')` | **Wipes the entire editor** |

The one sequence that works is a single atomic operation per call:

1. `execCommand('selectAll')`
2. `await ~20ms` so Lexical syncs its selection from the DOM
3. either a synthetic `paste` (replaces the selection, newlines intact) or a `Backspace` keydown to clear

Because step 2 awaits, this is the repo's **first async `injectText`**. Mirroring is per-keystroke, so it coalesces latest-wins: a write in flight just updates the pending value, and the newest text is replayed once it settles. That keeps fast typing from interleaving.

Six other strategies were tried and rejected first; the reasoning is captured in a comment block at the top of `kimi-preload.js` so the next person doesn't repeat it.

## Verification

No test suite in this repo, so this was driven over CDP against the live site.

**Per-code-point fidelity** through the real pipeline (control bar → `throttle(50)` → IPC → preload), asserting the composer matches exactly after *every* character — the check that separates a correct implementation from one that only looks right at the end:

- Test string `Line one\nLine two 中文测试\nx  y 😀 end` — deliberately covers newlines, CJK (IME risk), an astral-plane emoji (needs `Array.from`, not indexing), and a double space (`&nbsp;` conversion)
- **33/33 exact, logged out and logged in** (logged-in confirmed on a real `/chat/<uuid>` URL)
- Also passing: burst/coalesced input, delete-back-to-empty, post-submit desync, mid-string replace, recovery from a stray user drag-selection, idempotent repeats, leading/trailing spaces, blank lines

**Integration:** supersize gating (text reached only the supersized Kimi panel; Gemini untouched), New Chat, zoom ±, `kimi` round-tripping in `window-providers.json`, and a ChatGPT/Gemini regression pass after the shared-utils change.

**Packaged build:** verified in an actual universal DMG, not just in dev — dropdown lists all six providers and mirroring is exact.

No `userAgent` override needed: `kimi.com` serves the full app to Electron's default UA (HTTP 200, composer present), unlike Perplexity and Grok.

## Included bug fixes

**A bad key in `window-providers.json` launched the app with no window.** `loadProviderConfig()` trusted the file wholesale; `createProviderView` throws on an unknown provider, that throw escaped `createWindow()` into the un-`catch`ed `await` in `app.on('ready')`, and `mainWindow.show()` never ran. Reproduced before fixing (`UnhandledPromiseRejectionWarning`, 2 of 4 views built, live process with no UI), then confirmed it now falls back per slot and logs the reason. This is gitignored userland state a user cannot inspect, and a provider-name typo is exactly the mistake adding a provider invites.

**`changeProvider` destroyed the outgoing view before validating the incoming key**, leaving a dead `webContents` in `viewPositions` that every later broadcast trips on. Now builds the replacement first, then retires the old one. Tradeoff: both views exist briefly, and the new one begins `loadURL` before the old closes — no visual artifact, since `updateBounds()` runs after.

**The injected provider dropdown could not scroll.** It had `overflow: hidden` and no `max-height`, so it grew unbounded and could put the last option past the bottom of a supersize thumbnail panel with no way to reach it. Now capped with `overflowY: auto`. Honest note: at a 900px window the thumbnail is 280px and six options end at 270px, so the clipping was *marginal* rather than certain — the fix matters at smaller window heights and makes the menu robust to a seventh provider.

## Review notes

- `config/selectors.json` keeps short, specific selector lists on purpose. A generic `div[contenteditable='true']` tail could match Kimi's sidebar rename-conversation editor, which is a silently *wrong* panel — worse than a dead one.
- Kimi's submit selector is not a `<button>`: it's `div.send-button-container` wrapping an `svg`. Its appearance never changes with content, so it cannot be used as a "did the write land" signal.
- `persist:shared` is deliberate. A new partition would silently lose microphone and clipboard access, since those handlers are registered only for `persist:shared` in `main/index.js` — the bug `persist:grok` has today.

## Out of scope

- Permission handlers for `persist:grok` (pre-existing, unrelated).
- Bumping the `electron` devDependency off 31.7.7, whose notarization Apple revoked so it cannot run on macOS at all. Local dev needs `npm install --no-save electron@latest`. Note Electron 43 also emits a deprecation warning for the `console-message` signature at `window-manager.js:378` and `:422`, which that bump will require addressing.
- `saveProviderConfig` writes inside the app bundle, so provider switches do not persist in a packaged build (needs `app.getPath('userData')`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
